### PR TITLE
Fixed search bar enter problem

### DIFF
--- a/src/messenger-shortcuts.js
+++ b/src/messenger-shortcuts.js
@@ -129,7 +129,8 @@ function focusMessageInput() {
 }
 
 function selectFirstSearchResult() {
-  var first = document.querySelector('ul[role="listbox"] li div');
+  var contacts = document.querySelectorAll('ul[role="listbox"]')[1];
+  var first = contacts.querySelector('ul[role="listbox"] li div');
   if (first) {
     click(first);
   }
@@ -148,7 +149,8 @@ function toggleInfo() {
 }
 
 function getSearchBar() {
-  return getByAttr('input', 'type', 'text');
+  return document.querySelector('input[type="text"][placeholder="Search Messenger"]');
+  // return getByAttr('input', 'type', 'text');
 }
 
 function focusSearchBar() {


### PR DESCRIPTION
Facebook recently added a "Search in Messages" option at the top of the search bar on the left, so the Enter functionality was malfunctioning. This should be fixed with this pull request.